### PR TITLE
feat: Kotlin support added

### DIFF
--- a/build.go
+++ b/build.go
@@ -24,6 +24,7 @@ func build() {
 	prepare()
 	compileRes()
 	bundleRes(*useAAB)
+	compileKotlin()
 	compileJava()
 	bundleJava()
 	buildBundle(*useAAB)
@@ -94,14 +95,33 @@ func bundleRes(useAAB bool) {
 	}
 }
 
+func compileKotlin() {
+	kotlins := getFiles("src", "kt")
+	if len(kotlins) < 1 {
+		return
+	}
+
+	LogI("build", "compiling kotlin files")
+
+	jars := strings.Join(getFiles("jar", "jar"), ":")
+
+	args := []string{"-d", filepath.Join("build", "classes"), "-classpath", androidJar + ":" + jars, "src"}
+	args = append(args, kotlins...)
+	cmd := exec.Command(kotlincPath, args...)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		LogF("build", string(out), args)
+	}
+}
+
 // compileJava compiles java files in src dir and uses jar files in the jar dir as classpath
 func compileJava() {
 	LogI("build", "compiling java files")
 
-	javas := getFiles("src", "")
+	javas := getFiles("src", "java")
 	jars := strings.Join(getFiles("jar", "jar"), ":")
 
-	args := []string{"-d", filepath.Join("build", "classes"), "-classpath", androidJar + ":" + jars}
+	args := []string{"-d", filepath.Join("build", "classes"), "-classpath", androidJar + ":" + filepath.Join("build", "classes") + ":" + jars}
 	args = append(args, javas...)
 	cmd := exec.Command(javacPath, args...)
 	out, err := cmd.CombinedOutput()

--- a/doctor.go
+++ b/doctor.go
@@ -18,6 +18,9 @@ var (
 	javaBinPath string
 	javacPath   string
 
+	// kotlin sdk paths
+	kotlincPath   string
+
 	// android sdk paths
 	sdkPath       string
 	toolsPath     string
@@ -40,6 +43,8 @@ func doctor() {
 
 	LogI("doctor", "java", javaPath)
 	LogI("doctor", "javac", javacPath)
+
+	LogI("doctor", "kotlinc", kotlincPath)
 
 	LogI("doctor", "sdk", sdkPath)
 	LogI("doctor", "aapt2", aapt2Path)
@@ -99,6 +104,8 @@ func findSDKs() {
 		// hope the bin is in path
 		javacPath = "javac"
 	}
+
+	kotlincPath = "kotlinc"
 }
 
 // latestBuildTools checks the available build tools and picks the most recent one


### PR DESCRIPTION
The ability to use **kotlin** has been implemented.
The use of **kotlin** in a project considerably affects its compilation time, but gives us the various advantages and conveniences of **kotlin**.
Simply add a .kt file to the project and it will be detected and compiled with the '**kotlinc**' tool.
In case no .kt files are detected, the program simply follows the normal flow compiling only java files.